### PR TITLE
Add code coverage with Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0% # Ensure it always passes
+        threshold: 0% # No threshold drop is allowed
+        require: false # Do not require this status to pass the build
+        informational: true # Do not fail the build based on coverage

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,47 @@
+[run]
+branch = True
+omit =
+    *.bak
+    docs/*
+    nbs/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+    # Don't complain about abstract methods, they aren't run:
+    @(abc\.)?abstractmethod
+
+    @(typing\.)?overload
+
+    if TYPE_CHECKING:
+
+    # Don't complain about functions with ellipsis body
+    def .*:[\s]*\.\.\.$
+
+    # Don't complain about Protocol inheritance or generic inheritance
+    class .*\(Protocol(\[.*\])?(,.*)?.*\):
+
+[html]
+directory = coverage_html_report
+
+[paths]
+source =
+    src/sax/
+    src/tests/
+
+ignore_errors = True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,20 @@ jobs:
         with:
           name: tests-${{ matrix.os }}
           path: ./src/tests
+
+  test_coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install UV
+        uses: astral-sh/setup-uv@v7
+      - name: Install Just
+        uses: taiki-e/install-action@just
+      - name: Run tests with coverage
+        run: just cov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/justfile
+++ b/justfile
@@ -20,6 +20,9 @@ ipykernel:
 test: ipykernel
   uv run --dev pytest -s -n logical
 
+cov: ipykernel
+  uv run --dev pytest --cov=sax --cov-report=term-missing:skip-covered
+
 docs:
   sed 's|](docs/|](|g' README.md > docs/index.md
   sed 's|^#|###|g' CHANGELOG.md | sed 's|^### \[0|## [0|g' > docs/changelog.md


### PR DESCRIPTION
## Summary
- Add `.coveragerc` with branch coverage and standard exclusion patterns
- Add `.codecov.yml` with informational-only status (won't block PRs)
- Add `cov` target to justfile for local coverage runs
- Add `test_coverage` CI job that uploads results to Codecov

## Test plan
- [ ] Add `CODECOV_TOKEN` secret to repo from codecov.io
- [ ] Verify CI `test_coverage` job passes
- [ ] Run `just cov` locally to confirm coverage report

🤖 Generated with [Claude Code](https://claude.com/claude-code)