### PR TITLE
Fix model lookup for numbered component variants

### DIFF
--- a/src/sax/circuits.py
+++ b/src/sax/circuits.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from collections.abc import Iterable, Iterator
 from functools import partial
@@ -199,8 +200,9 @@ def circuit(
     current_models = {}
     model_names = list(nx.topological_sort(dependency_dag))[::-1]
     for model_name in model_names:
-        if model_name in models:
-            new_models[model_name] = models[model_name]
+        resolved_name = _strip_counted_suffix(model_name, models)
+        if resolved_name in models:
+            new_models[model_name] = models[resolved_name]
             continue
 
         flatnet = recnet[model_name]
@@ -242,15 +244,17 @@ def _create_dag(
     g = nx.DiGraph()
 
     for model_name, subnetlist in netlist.items():
+        resolved_model_name = _strip_counted_suffix(model_name, models)
         if model_name not in all_models:
-            all_models[model_name] = models.get(model_name, subnetlist)
+            all_models[model_name] = models.get(resolved_model_name, subnetlist)
             g.add_node(model_name)
-        if model_name in models:
+        if resolved_model_name in models:
             continue
         for instance in subnetlist["instances"].values():
             component = instance["component"]
+            resolved_component = _strip_counted_suffix(component, models)
             if component not in all_models:
-                all_models[component] = models.get(component)
+                all_models[component] = models.get(resolved_component)
                 g.add_node(component)
             g.add_edge(model_name, component)
 
@@ -374,7 +378,8 @@ def _flat_circuit(
 
     inst2model = {}
     for k, inst in instances.items():
-        inst2model[k] = models[inst["component"]]
+        component = _strip_counted_suffix(inst["component"], models)
+        inst2model[k] = models[component]
 
     model_settings = {name: get_settings(model) for name, model in inst2model.items()}
     netlist_settings = {
@@ -458,7 +463,9 @@ def _find_missing_models(
         models = {}
     models = {**models, **extra_models}
     required_models = _find_leaves(dag)
-    missing_models = [m for m in required_models if m not in models]
+    missing_models = [
+        m for m in required_models if _strip_counted_suffix(m, models) not in models
+    ]
     return models, required_models, missing_models
 
 
@@ -666,6 +673,21 @@ def _validate_netlist_ports(netlist: sax.RecursiveNetlist) -> None:
 
 def _strip_array_index(s: sax.InstanceName) -> sax.Name:
     return s.split("<")[0]
+
+
+def _strip_counted_suffix(name: str, available: dict) -> str:
+    """Strip trailing numeric suffix (e.g. 'coupler2' -> 'coupler').
+
+    gdsfactory's CountedNetlistNamer appends numeric suffixes to deduplicate
+    cell names in recursive netlists. Only strips when the exact name is not
+    found and the base name exists in ``available``.
+    """
+    if name in available:
+        return name
+    base = re.sub(r"\d+$", "", name)
+    if base and base in available:
+        return base
+    return name
 
 
 def resolve_array_instance(name: sax.Name, inst: sax.Instance) -> sax.Instances:

--- a/src/tests/test_circuit.py
+++ b/src/tests/test_circuit.py
@@ -117,8 +117,97 @@ def test_circuit_with_empty_ports_subnetlist() -> None:
     assert set(sax.get_ports(result)) == {"in", "out"}
 
 
+def test_numbered_component_variants() -> None:
+    """Numbered component variants from recursive netlists resolve to the base model.
+
+    gdsfactory's CountedNetlistNamer appends numeric suffixes (coupler, coupler2, ...)
+    when exporting recursive netlists. All variants should resolve to the base model.
+    See https://github.com/gdsfactory/sax/issues/120.
+    """
+    netlist = {
+        "top_level": {
+            "instances": {
+                "lft": {"component": "coupler"},
+                "top": {"component": "waveguide"},
+                "btm": {"component": "waveguide2"},
+                "rgt": {"component": "coupler2"},
+            },
+            "connections": {
+                "lft,out0": "btm,in0",
+                "btm,out0": "rgt,in0",
+                "lft,out1": "top,in0",
+                "top,out0": "rgt,in1",
+            },
+            "ports": {
+                "in0": "lft,in0",
+                "in1": "lft,in1",
+                "out0": "rgt,out0",
+                "out1": "rgt,out1",
+            },
+        },
+        "coupler": {
+            "instances": {
+                "wg": {"component": "waveguide"},
+            },
+            "connections": {},
+            "ports": {"in0": "wg,in0", "out0": "wg,out0"},
+        },
+        "coupler2": {
+            "instances": {
+                "wg": {"component": "waveguide"},
+            },
+            "connections": {},
+            "ports": {"in0": "wg,in0", "out0": "wg,out0"},
+        },
+    }
+
+    models = {
+        "coupler": sax.models.coupler_ideal,
+        "waveguide": sax.models.straight,
+    }
+
+    circuit_fn, _info = sax.circuit(netlist, models)
+    result = circuit_fn()
+    ports = sax.get_ports(result)
+    assert "in0" in ports
+    assert "out0" in ports
+
+
+def test_numbered_variant_explicit_model_takes_priority() -> None:
+    """When an explicit model exists for a numbered variant, use it directly."""
+    netlist = {
+        "instances": {
+            "wg1": {"component": "waveguide"},
+            "wg2": {"component": "waveguide2"},
+        },
+        "connections": {
+            "wg1,out0": "wg2,in0",
+        },
+        "ports": {
+            "in": "wg1,in0",
+            "out": "wg2,out0",
+        },
+    }
+
+    def custom_waveguide2(**kwargs: sax.SettingsValue) -> sax.SType:
+        return sax.models.straight(**kwargs)
+
+    models = {
+        "waveguide": sax.models.straight,
+        "waveguide2": custom_waveguide2,
+    }
+
+    circuit_fn, _info = sax.circuit(netlist, models)
+    result = circuit_fn()
+    ports = sax.get_ports(result)
+    assert "in" in ports
+    assert "out" in ports
+
+
 if __name__ == "__main__":
     print(test_circuit())
     print(test_1port_circuit())
     print(test_circuit_with_portless_subnetlist())
     print(test_circuit_with_empty_ports_subnetlist())
+    print(test_numbered_component_variants())
+    print(test_numbered_variant_explicit_model_takes_priority())


### PR DESCRIPTION
## Summary

- Adds `_strip_counted_suffix()` helper that strips trailing numeric suffixes (e.g. `coupler2` → `coupler`) added by gdsfactory's `CountedNetlistNamer` in recursive netlists
- Applied to DAG construction, model validation, the main circuit build loop, and the flat circuit builder — all numbered variants now resolve to the base analytical model
- Conservative: only strips when the exact name isn't found AND the base name exists (explicit numbered models still take priority)

Closes #120

## Test plan

- [x] New test `test_numbered_component_variants`: recursive netlist with `coupler`/`coupler2` and `waveguide`/`waveguide2` — all resolve to base model
- [x] New test `test_numbered_variant_explicit_model_takes_priority`: explicit `waveguide2` model is used directly, not stripped
- [x] Full existing test suite passes (90/90, 0 regressions)
- [x] Ruff lint and format pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)