### PR TITLE
fix: add xarray[io] extra for netCDF support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
   "sympy>=1.14.0,<2.0.0",
   "tqdm>=4.60.0,<5.0.0",
   "typing-extensions>=4.13.2,<5.0.0",
-  "xarray>=2025.1.2,<2027.0.0"
+  "xarray[io]>=2025.1.2,<2027.0.0"
 ]
 description = "Autograd and XLA for S-parameters"
 keywords = [


### PR DESCRIPTION
## Motivation

`sax` depends on `xarray` but not its netCDF backend. Several PDKs ship their data as netCDF files, and without `netCDF4` installed, `xarray.open_dataset(...)` raises a backend error. In gdsfactory+ this surfaces as a silent failure, making it hard to diagnose.

## Change

Pull in xarray's `io` extra so the netCDF dependencies are installed with `sax`:

```diff
- "xarray>=2025.1.2,<2027.0.0"
+ "xarray[io]>=2025.1.2,<2027.0.0"
```

The `io` extra includes `netCDF4`, `h5netcdf`, `scipy`, `zarr`, `fsspec`, `cftime`, and `pooch`.